### PR TITLE
chore: mark the starting point as `key_points`

### DIFF
--- a/autowsgr/data/map/decisive_battle/3.yaml
+++ b/autowsgr/data/map/decisive_battle/3.yaml
@@ -7,17 +7,17 @@ key_points:
     - ""
   4:
     - ""
-    - "CFH"
+    - "ABCDEFH"
     - "BFH"
     - "DHJ"
   5:
     - ""
-    - "DFH"
+    - "ABCDEFH"
     - "DGJ"
     - "CGJ"
   6:
     - ""
-    - "BGJ"
+    - "ABCDEGJ"
     - "CHJ"
     - "DGJ"
 map_end:


### PR DESCRIPTION
* 将决战的起始点 `ABCDE` 标记为 `key_points`, 用于进入夜战，提高 B 胜的概率，避免战败而无法获得费用