### PR TITLE
feat: 日常挂机策略增加演习舰队配置

### DIFF
--- a/autowsgr/fight/exercise.py
+++ b/autowsgr/fight/exercise.py
@@ -123,9 +123,17 @@ class NormalExerciseInfo(FightInfo):
 
 
 class NormalExercisePlan(FightPlan):
-    """ " 常规战斗的决策模块"""
+    """
+    常规战斗的决策模块
 
-    def __init__(self, timer: Timer, plan_path) -> None:
+    Args:
+        plan_path: 以 PLAN_ROOT/exercise 为根的相对路径
+
+        fleet_id: 指定舰队编号, 如果为 None 则使用计划中的参数
+
+    """
+
+    def __init__(self, timer: Timer, plan_path: str, fleet_id: int | None) -> None:
         super().__init__(timer)
 
         # 加载默认配置
@@ -140,6 +148,11 @@ class NormalExercisePlan(FightPlan):
 
         # 加载节点配置
         node_defaults = self.node_defaults
+
+        # 从参数加载计划
+        if fleet_id is not None:
+            node_defaults['fleet_id'] = fleet_id  # 舰队编号
+
         self.nodes = {}
         for node_name in self.selected_nodes:
             node_args = copy.deepcopy(node_defaults)

--- a/autowsgr/scripts/daily_api.py
+++ b/autowsgr/scripts/daily_api.py
@@ -27,7 +27,11 @@ class DailyOperation:
                 plan_path=self.config.battle_type,
             )
         if self.config.auto_exercise:
-            self.exercise_plan = NormalExercisePlan(self.timer, 'plan_1')
+            self.exercise_plan = NormalExercisePlan(
+                self.timer,
+                plan_path='plan_1',
+                fleet_id=self.config.exercise_fleet_id,
+            )
             self.complete_time = None
 
         if self.config.auto_normal_fight:

--- a/autowsgr/user_config.py
+++ b/autowsgr/user_config.py
@@ -88,6 +88,8 @@ class DailyAutomationConfig(BaseConfig):
     """打哪个战役"""
     auto_exercise: bool = True
     """自动打完每日的三次演习"""
+    exercise_fleet_id: int | None = None
+    """演习出征舰队"""
 
     # 常规战
     auto_normal_fight: bool = True

--- a/examples/exercise.py
+++ b/examples/exercise.py
@@ -3,5 +3,5 @@ from autowsgr.scripts.main import start_script
 
 
 timer = start_script('./user_settings.yaml')
-exf = NormalExercisePlan(timer, 'plan_1')
+exf = NormalExercisePlan(timer, plan_path='plan_1', fleet_id=2)  # 修改 fleet_id 为演习出征舰队编号
 exf.run()

--- a/examples/user_settings.yaml
+++ b/examples/user_settings.yaml
@@ -12,6 +12,7 @@ daily_automation:
   battle_type: 困难巡洋
 
   auto_exercise: True
+  exercise_fleet_id: 2 # 演习出征舰队
 
   auto_normal_fight: True
   normal_fight_tasks:


### PR DESCRIPTION
* 日常挂机策略增加 `exercise_fleet_id` 配置项，用于指定演习出征舰队