### PR TITLE
fix: 裁剪过的图片绕过locator

### DIFF
--- a/autowsgr/port/ship.py
+++ b/autowsgr/port/ship.py
@@ -63,9 +63,10 @@ class Fleet:
         if self.fleet_id is not None:
             move_team(self.timer, self.fleet_id)
 
-        ships = self.timer.recognize_ship(
+        ships = self.timer.recognize(
             self.timer.get_screen()[433:459],
-            self.timer.ship_names,
+            candidates=self.timer.ship_names,
+            multiple=True,
         )
         self.ships = [None] * 7
 


### PR DESCRIPTION
loctator疑似在传入已经经过剪裁的图片时会出错，将裁剪过的图片绕过locator