### PR TITLE
fix: 索敌失败时强制复纵

### DIFF
--- a/autowsgr/configs.py
+++ b/autowsgr/configs.py
@@ -389,7 +389,7 @@ class NodeConfig(BaseConfig):
     """进入战斗是否退出"""
     formation: Formation = Formation.double_column
     """阵型选择"""
-    formation_when_spot_enemy_fails: Formation = Formation.double_column
+    formation_when_spot_enemy_fails: Formation | None = None
     """索敌失败时阵型选择"""
 
     # 夜战, 前进阶段
@@ -403,7 +403,10 @@ class NodeConfig(BaseConfig):
     def __post_init__(self) -> None:
         if not isinstance(self.formation, Formation):
             object.__setattr__(self, 'formation', Formation(self.formation))
-        if not isinstance(self.formation_when_spot_enemy_fails, Formation):
+        if (
+            not isinstance(self.formation_when_spot_enemy_fails, Formation)
+            and self.formation_when_spot_enemy_fails is not None
+        ):
             object.__setattr__(
                 self,
                 'formation_when_spot_enemy_fails',


### PR DESCRIPTION
formation_when_spot_enemy_fails设置默认值后，索敌失败强制使用该值
实际应当是用户在plan中设置该值后才会使用