### PR TITLE
fix: 强制在通过plan.run_for_times创建的任务开始时检查远征

### DIFF
--- a/autowsgr/fight/common.py
+++ b/autowsgr/fight/common.py
@@ -329,7 +329,7 @@ class FightPlan(Protocol):
         """
         assert times >= 1
         expedition = Expedition(self.timer)
-        expedition.run(True)
+        self.timer.goto_game_page('map_page')
         for i in range(times):
             if time.time() - self.timer.last_expedition_check_time >= gap:
                 expedition.run(True)

--- a/autowsgr/fight/common.py
+++ b/autowsgr/fight/common.py
@@ -329,6 +329,7 @@ class FightPlan(Protocol):
         """
         assert times >= 1
         expedition = Expedition(self.timer)
+        expedition.run(True)
         for i in range(times):
             if time.time() - self.timer.last_expedition_check_time >= gap:
                 expedition.run(True)


### PR DESCRIPTION
ref: 通过plan.run_for_times创建的任务在最开始不会检查远征